### PR TITLE
fixed iBodies element injection

### DIFF
--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFAbstractFootnoteEndnote.java
@@ -334,7 +334,7 @@ public abstract class XWPFAbstractFootnoteEndnote  implements Iterable<XWPFParag
             cursor = t.newCursor();
             while (cursor.toPrevSibling()) {
                 o = cursor.getObject();
-                if (o instanceof CTP || o instanceof CTTbl)
+                if (o instanceof CTP || o instanceof CTTbl || o instanceof CTSdtBlock)
                     i++;
             }
             bodyElements.add(i, newT);
@@ -383,7 +383,7 @@ public abstract class XWPFAbstractFootnoteEndnote  implements Iterable<XWPFParag
             }
             while (cursor.toPrevSibling()) {
                 o = cursor.getObject();
-                if (o instanceof CTP || o instanceof CTTbl)
+                if (o instanceof CTP || o instanceof CTTbl || o instanceof CTSdtBlock)
                     i++;
             }
             bodyElements.add(i, newP);

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFComment.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFComment.java
@@ -179,7 +179,7 @@ public class XWPFComment implements IBody {
             p2.dispose();
             while (cursor.toPrevSibling()) {
                 o = cursor.getObject();
-                if (o instanceof CTP || o instanceof CTTbl)
+                if (o instanceof CTP || o instanceof CTTbl || o instanceof CTSdtBlock)
                     i++;
             }
             bodyElements.add(i, newP);
@@ -224,7 +224,7 @@ public class XWPFComment implements IBody {
             XmlCursor cursor2 = t.newCursor();
             while (cursor2.toPrevSibling()) {
                 o = cursor2.getObject();
-                if (o instanceof CTP || o instanceof CTTbl) {
+                if (o instanceof CTP || o instanceof CTTbl || o instanceof CTSdtBlock) {
                     i++;
                 }
             }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFDocument.java
@@ -841,7 +841,7 @@ public class XWPFDocument extends POIXMLDocument implements Document, IBody {
                 cursor.toCursor(tableCursor);
                 while (cursor.toPrevSibling()) {
                     o = cursor.getObject();
-                    if (o instanceof CTP || o instanceof CTTbl) {
+                    if (o instanceof CTP || o instanceof CTTbl || o instanceof CTSdtBlock) {
                         i++;
                     }
                 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFHeaderFooter.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFHeaderFooter.java
@@ -479,7 +479,7 @@ public abstract class XWPFHeaderFooter extends POIXMLDocumentPart implements IBo
             }
             while (cursor.toPrevSibling()) {
                 o = cursor.getObject();
-                if (o instanceof CTP || o instanceof CTTbl)
+                if (o instanceof CTP || o instanceof CTTbl || o instanceof CTSdtBlock)
                     i++;
             }
             bodyElements.add(i, newP);
@@ -524,7 +524,7 @@ public abstract class XWPFHeaderFooter extends POIXMLDocumentPart implements IBo
             try {
                 while (cursor2.toPrevSibling()) {
                     o = cursor2.getObject();
-                    if (o instanceof CTP || o instanceof CTTbl) {
+                    if (o instanceof CTP || o instanceof CTTbl || o instanceof CTSdtBlock) {
                         i++;
                     }
                 }

--- a/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContentBlock.java
+++ b/poi-ooxml/src/main/java/org/apache/poi/xwpf/usermodel/XWPFSDTContentBlock.java
@@ -137,7 +137,7 @@ public class XWPFSDTContentBlock implements ISDTContent, ISDTContentBlock {
                 cursor.toCursor(newParaPos);
                 while (cursor.toPrevSibling()) {
                     o = cursor.getObject();
-                    if (o instanceof CTP || o instanceof CTTbl) {
+                    if (o instanceof CTP || o instanceof CTTbl || o instanceof CTSdtBlock) {
                         i++;
                     }
                 }
@@ -211,7 +211,7 @@ public class XWPFSDTContentBlock implements ISDTContent, ISDTContentBlock {
                 cursor.toCursor(tableCursor);
                 while (cursor.toPrevSibling()) {
                     o = cursor.getObject();
-                    if (o instanceof CTP || o instanceof CTTbl) {
+                    if (o instanceof CTP || o instanceof CTTbl || o instanceof CTSdtBlock) {
                         i++;
                     }
                 }


### PR DESCRIPTION
Ошибка проявлялась в случае если есть темплейт c элементами
```
SdtBlock
Paragraph
XWPFTable
Paragraph
SdtBlock
```
когда выполнялся инжект новой таблицы перед последним sdt, таблица добавлялась с некорректным индексом. Иcправил для всех iBody